### PR TITLE
Find and fix three code bugs

### DIFF
--- a/src/talktype/app.py
+++ b/src/talktype/app.py
@@ -284,7 +284,7 @@ def stop_recording(
         )
         raw = " ".join(seg.text for seg in segments).strip()
         print(f"📝 Raw: {raw!r}")
-        text = normalize_text(raw if smart_quotes else raw.replace("“","\"").replace("”","\""))
+        text = normalize_text(raw, use_smart_quotes=smart_quotes, preserve_soft_break_marker=True)
 
         # Simple spacing: always add period+space or just space when auto features are on
         if auto_period and text and not text.rstrip().endswith((".","?","!","…")):

--- a/src/talktype/config.py
+++ b/src/talktype/config.py
@@ -1,6 +1,17 @@
 from __future__ import annotations
-import os, tomllib
+import os
 from dataclasses import dataclass
+
+try:
+    import tomllib
+    def _load_toml(path: str) -> dict:
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+except ModuleNotFoundError:
+    import toml
+    def _load_toml(path: str) -> dict:
+        with open(path, "r", encoding="utf-8") as f:
+            return toml.load(f)
 
 CONFIG_PATH = os.path.expanduser("~/.config/talktype/config.toml")
 
@@ -25,8 +36,7 @@ def load_config() -> Settings:
     s = Settings()
     if os.path.exists(CONFIG_PATH):
         try:
-            with open(CONFIG_PATH, "rb") as f:
-                data = tomllib.load(f)
+            data = _load_toml(CONFIG_PATH)
             s.model = str(data.get("model", s.model))
             s.device = str(data.get("device", s.device))
             s.hotkey = str(data.get("hotkey", s.hotkey))

--- a/src/talktype/tray.py
+++ b/src/talktype/tray.py
@@ -89,9 +89,8 @@ class DictationTray:
     def start_service(self, _):
         """Start the dictation service."""
         try:
-            # Start the app in background
-                        subprocess.Popen(["python3", "-m", "src.talktype.app"],
-                            cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+            project_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+            subprocess.Popen([sys.executable, "-m", "talktype.app"], cwd=project_dir)
             GLib.timeout_add_seconds(2, self.update_icon_status_once)
         except Exception as e:
             print(f"Failed to start service: {e}")
@@ -121,12 +120,8 @@ class DictationTray:
     def open_preferences(self, _):
         """Launch preferences window."""
         try:
-            # Use direct Python path for more reliable execution
-            import os
-                    project_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__))
-        python_path = "python3"  # Use system Python instead of hardcoded path
-            subprocess.Popen([python_path, "-m", "src.talktype.prefs"], 
-                           cwd=project_dir)
+            project_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+            subprocess.Popen([sys.executable, "-m", "talktype.prefs"], cwd=project_dir)
         except Exception as e:
             print(f"Failed to open preferences: {e}")
     


### PR DESCRIPTION
Fixes three bugs: broken tray controls, config loading on Python 3.10, and ineffective smart quotes preference.

*   **Tray controls**: The `start_service` and `open_preferences` functions in `tray.py` had syntax errors and used incorrect module paths, preventing them from launching the app or preferences. This fix corrects the syntax and uses `sys.executable` with the proper `talktype.*` module paths for reliable execution.
*   **Config loading**: `config.py` failed to load on Python 3.10 due to `tomllib` being a Python 3.11+ module. This change adds a compatibility layer to use `toml` for older Python versions while retaining `tomllib` for newer ones.
*   **Smart quotes**: The `smart_quotes` preference was not applied correctly because curly quotes were introduced *after* the initial sanitization in `normalize_text`. This fix introduces a `use_smart_quotes` parameter to `normalize_text` and passes the preference from `app.py`, ensuring the toggle is respected. It also refines the handling of the `§SHIFT_ENTER§` marker for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-d05d87d9-ffb5-4e22-bc17-d00830195b40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d05d87d9-ffb5-4e22-bc17-d00830195b40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

